### PR TITLE
Fix Seer/Overseer API path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1976,7 +1976,7 @@ class OverseerrServer {
       }
 
       // Don't cache summary queries as they need fresh data
-      const response = await this.axiosInstance.get('/requests', { params });
+      const response = await this.axiosInstance.get('/request', { params });
       const requests = response.data;
 
       const statusCounts: Record<string, number> = {};
@@ -2014,7 +2014,7 @@ class OverseerrServer {
         params.filter = filter;
       }
 
-      const response = await this.axiosInstance.get('/requests', { params });
+      const response = await this.axiosInstance.get('/request', { params });
       requests = response.data;
       this.cache.set('requests', cacheKey, requests);
     }


### PR DESCRIPTION
## Summary

The "list requests" calls in `handleListRequests` hit `GET /requests` (plural), but neither the Overseerr nor the Seerr/Jellyseerr API exposes that path — the list endpoint is `GET /request` (singular). The plural path returns **404** on every backend, breaking both summary and paginated request listing.

This fixes the two occurrences in `src/index.ts` to use `/request`.

## Verification

Confirmed against the canonical OpenAPI specs of both upstreams:

| API | Spec file | List endpoint |
|-----|-----------|---------------|
| Seerr | `seerr-team/seerr` → `seerr-api.yml` | `GET /request` ("Get all requests") |
| Overseerr | `sct/overseerr` → `overseerr-api.yml` | `GET /request` |

Neither spec defines a `/requests` path. The other request calls in the file already use the correct singular form (`POST /request`, `GET /request/{requestId}`), so this brings the list calls in line.

The server uses a single `axiosInstance` against `${SEERR_URL}/api/v1` regardless of backend, so the fix applies uniformly to Overseerr, Jellyseerr, and Seerr. The `{ pageInfo, results }` response shape is identical across both specs and unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)