### PR TITLE
Release v2.1.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ temp/
 # Local context management
 .kilo/
 .opencode/
+opencode.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [2.1.3] - 2026-05-20
+
+### Fixed
+- **Request API path**: Fixed `manage_media_requests` returning 404 errors — the list/summary endpoints were using `/requests` (plural) instead of the correct `/request` (singular) API path
+
+### Changed
+- **Dependencies**: Bumped `@commitlint/cli` to 21.0.1, `@commitlint/config-conventional` to 21.0.1, `@types/node` to 25.9.0, `axios` to 1.16.1, `typescript` to 6.0.3, `@modelcontextprotocol/sdk` to 1.29.0
+- **Docker**: Bumped base image from `node:25-alpine` to `node:26-alpine`
+- **CI**: Bumped `aquasecurity/trivy-action` to 0.36.0; allowed CI to see Trivy scan results
+- **Gitignore**: Added `opencode.json` to `.gitignore`
+
 ## [2.1.2] - 2026-04-08
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Docker](https://img.shields.io/badge/docker-%230db7ed.svg?style=flat&logo=docker&logoColor=white)](https://github.com/jhomen368/overseerr-mcp/pkgs/container/overseerr-mcp)
-[![Version](https://img.shields.io/badge/version-2.1.2-blue.svg)](https://github.com/jhomen368/overseerr-mcp)
+[![Version](https://img.shields.io/badge/version-2.1.3-blue.svg)](https://github.com/jhomen368/overseerr-mcp)
 [![PayPal](https://img.shields.io/badge/Donate-PayPal-blue.svg)](https://www.paypal.com/donate?hosted_button_id=PBRD7FXKSKAD2)
 
 > **A [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server for Overseerr and Seerr (the unified successor) that enables AI assistants to search, request, and manage media through the Model Context Protocol.**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jhomen368/overseerr-mcp",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jhomen368/overseerr-mcp",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jhomen368/overseerr-mcp",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "MCP server for Overseerr/Seerr media request automation",
   "type": "module",
   "author": "jhomen368",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '2.1.2';
+export const VERSION = '2.1.3';


### PR DESCRIPTION
## Changes

### Fixed
- **Request API path**: Fixed `manage_media_requests` returning 404 errors — list/summary endpoints were using `/requests` (plural) instead of `/request` (singular)

### Changed
- Bumped dependencies: @commitlint/cli 21.0.1, @commitlint/config-conventional 21.0.1, @types/node 25.9.0, axios 1.16.1, typescript 6.0.3, @modelcontextprotocol/sdk 1.29.0
- Docker base image: node:25-alpine → node:26-alpine
- CI: trivy-action 0.36.0; Trivy scan results visible
- Added opencode.json to .gitignore

### Pre-release tests
All 27 checks PASSED (build, 19 functional, 5 HTTP transport)