### PR TITLE
release: v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [2.2.0] - 2026-06-05
+
+### Added
+- **Streamable HTTP transport**: Replaced legacy SSE transport with the MCP Streamable HTTP transport, enabling proper multi-session support and broader client compatibility
+
+### Fixed
+- **Session management**: Hardened HTTP session handling — unknown session IDs now return 404, requests without a session ID return 400
+- **Pagination metadata**: Fixed `pageInfo` always returning `undefined` in `manage_media_requests` list responses due to a casing mismatch (`PageInfo` → `pageInfo`)
+
+### Changed
+- **Dependencies**: Bumped `@commitlint/cli` to 21.0.2, `@commitlint/config-conventional` to 21.0.2, `@types/node` to 25.9.1, `qs` (transitive); patched `hono` to 4.12.23 to resolve moderate security vulnerabilities (IP restriction bypass, cookie injection, JWT scheme validation, path routing)
+
 ## [2.1.3] - 2026-05-20
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Docker](https://img.shields.io/badge/docker-%230db7ed.svg?style=flat&logo=docker&logoColor=white)](https://github.com/jhomen368/overseerr-mcp/pkgs/container/overseerr-mcp)
-[![Version](https://img.shields.io/badge/version-2.1.3-blue.svg)](https://github.com/jhomen368/overseerr-mcp)
+[![Version](https://img.shields.io/badge/version-2.2.0-blue.svg)](https://github.com/jhomen368/overseerr-mcp)
 [![PayPal](https://img.shields.io/badge/Donate-PayPal-blue.svg)](https://www.paypal.com/donate?hosted_button_id=PBRD7FXKSKAD2)
 
 > **A [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server for Overseerr and Seerr (the unified successor) that enables AI assistants to search, request, and manage media through the Model Context Protocol.**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jhomen368/overseerr-mcp",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jhomen368/overseerr-mcp",
-      "version": "2.1.3",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",
@@ -1712,9 +1712,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jhomen368/overseerr-mcp",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "description": "MCP server for Overseerr/Seerr media request automation",
   "type": "module",
   "author": "jhomen368",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2003,7 +2003,7 @@ class OverseerrServer {
 
     // Regular list mode - use pagination
     const cacheKey = { filter, take, skip, sort };
-    let requests = this.cache.get<{ results: MediaRequest[]; PageInfo: any }>('requests', cacheKey);
+    let requests = this.cache.get<{ results: MediaRequest[]; pageInfo: any }>('requests', cacheKey);
 
     if (!requests) {
       const params: any = {
@@ -2031,7 +2031,7 @@ class OverseerrServer {
           type: 'text',
           text: JSON.stringify({
             results: formatted,
-            pageInfo: requests?.PageInfo,
+            pageInfo: requests?.pageInfo,
           }, null, 2),
         },
       ],

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = '2.1.3';
+export const VERSION = '2.2.0';


### PR DESCRIPTION
## Release v2.2.0

### Added
- Streamable HTTP transport replacing legacy SSE transport

### Fixed
- HTTP session management hardening (404 unknown sessions, 400 no session)
- `pageInfo` pagination metadata always undefined in `manage_media_requests` (casing bug)

### Changed
- Dependency bumps: `@commitlint/cli` 21.0.2, `@commitlint/config-conventional` 21.0.2, `@types/node` 25.9.1
- Security: patched `hono` to 4.12.23 (4 moderate CVEs)

---
All 27/27 tests pass.