### PR TITLE
fix: reject empty seasons array before API call

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1799,6 +1799,14 @@ class OverseerrServer {
       }
     }
 
+    // Guard: reject empty seasons before dry-run or real request — avoids silent success with no actual request
+    if (mediaType === 'tv' && (!expandedSeasons || expandedSeasons.length === 0)) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        'No valid seasons specified. Use seasons: [1, 2, 3] for specific seasons or seasons: "all" for all seasons.'
+      );
+    }
+
     // Get media title with caching
     const details = await this.getMediaDetails(mediaType!, mediaId!);
     let mediaTitle: string;
@@ -1824,14 +1832,6 @@ class OverseerrServer {
           },
         ],
       };
-    }
-
-    // Guard: reject empty seasons before hitting the API — avoids silent success with no actual request
-    if (mediaType === 'tv' && (!expandedSeasons || expandedSeasons.length === 0)) {
-      throw new McpError(
-        ErrorCode.InvalidParams,
-        'No valid seasons specified. Use seasons: [1, 2, 3] for specific seasons or seasons: "all" for all seasons.'
-      );
     }
 
     // Actually make the request

--- a/src/index.ts
+++ b/src/index.ts
@@ -1826,6 +1826,14 @@ class OverseerrServer {
       };
     }
 
+    // Guard: reject empty seasons before hitting the API — avoids silent success with no actual request
+    if (mediaType === 'tv' && (!expandedSeasons || expandedSeasons.length === 0)) {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        'No valid seasons specified. Use seasons: [1, 2, 3] for specific seasons or seasons: "all" for all seasons.'
+      );
+    }
+
     // Actually make the request
     const requestBody: any = {
       mediaType,


### PR DESCRIPTION
## Problem

When a TV show request was made with `seasons` in an invalid format (e.g. a bare number `1` instead of an array `[1]`), the value silently degraded to `expandedSeasons = []`. The empty array is truthy in JS, so the server sent `seasons: []` to the Overseerr API and returned:

```json
{
  "success": true,
  "status": "UNKNOWN",
  "message": "Successfully requested The Grand Tour"
}
```

Nothing actually appeared in Overseerr.

## Root Cause

The `else` branch in the seasons expansion logic (line ~1676) had no handler for a bare number input, so it fell through to `expandedSeasons = []`. An empty array is truthy, so the `seasons: []` body was sent to the API with no error raised.

## Fix

Add a guard at `src/index.ts:1829` before the POST `/request` call. If `expandedSeasons` is empty or missing for a TV request, throw `InvalidParams` with a clear, actionable message instead of proceeding silently.

**Before:** `seasons: 1` → `success: true, status: UNKNOWN`, nothing created in Overseerr  
**After:** `seasons: 1` → `InvalidParams: No valid seasons specified. Use seasons: [1, 2, 3] or seasons: "all"`

## Notes

- Movies are unaffected — all seasons handling is gated on `mediaType === 'tv'`
- The primary fix was correcting the calling agent to send `seasons: [1]`; this is a defensive server-side improvement so bad input fails loudly rather than silently