### PR TITLE
fix(ci): use npm install for Dependabot PRs to handle stale transitive deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           cache: 'npm'
       
       - name: Install dependencies
-        run: npm ci
+        run: ${{ github.actor == 'dependabot[bot]' && 'npm install' || 'npm ci' }}
       
       - name: Run npm audit
         run: npm audit --audit-level=moderate


### PR DESCRIPTION
## Problem

Dependabot PRs were failing CI with `npm ci` because Dependabot bumps direct dependencies without always regenerating transitive deps in `package-lock.json`. This has already happened twice (see `5433cab`).

## Fix

Use `npm install` only when the actor is `dependabot[bot]`, keeping `npm ci` for all other PRs.

```yaml
run: ${{ github.actor == 'dependabot[bot]' && 'npm install' || 'npm ci' }}
```

- Dependabot PRs → `npm install` (resolves stale transitive deps)
- Everything else → `npm ci` (strict lock file enforcement preserved)

This avoids masking real failures on non-Dependabot PRs while permanently fixing the recurring Dependabot issue.