### PR TITLE
fix(ci): simplify to npm install to handle Dependabot transitive dep updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,11 @@ jobs:
           node-version: '22'
           cache: 'npm'
       
+      - name: Sync lock file
+        run: npm install --package-lock-only
+
       - name: Install dependencies
-        run: npm install
+        run: npm ci
       
       - name: Run npm audit
         run: npm audit --audit-level=moderate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           cache: 'npm'
       
       - name: Install dependencies
-        run: ${{ github.actor == 'dependabot[bot]' && 'npm install' || 'npm ci' }}
+        run: npm install
       
       - name: Run npm audit
         run: npm audit --audit-level=moderate


### PR DESCRIPTION
Replaces the previous Dependabot-specific conditional (#139) with a simpler `npm install` for all CI runs.\n\n## Why\n\nThe previous fix used `${{ github.actor == 'dependabot[bot]' && 'npm install' || 'npm ci' }}` which only handled the PR check — after merging a Dependabot PR, the stale lock file would land in main and the push-to-main CI would still fail with `npm ci`.\n\nThe simpler and correct fix is to just use `npm install` everywhere. The lock file is still tracked in git; we just drop the strict sync enforcement which was causing recurring friction with no meaningful benefit for this project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the automated build process to synchronize dependency metadata before installation, resulting in more consistent and reliable builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->