### PR TITLE
fix(ci): remove unnecessary build steps from CodeQL workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -33,18 +33,6 @@ jobs:
           languages: ${{ matrix.language }}
           queries: security-extended,security-and-quality
       
-      - name: Setup Node.js
-        uses: actions/setup-node@v7
-        with:
-          node-version: '20'
-          cache: 'npm'
-      
-      - name: Install dependencies
-        run: npm ci
-      
-      - name: Build project
-        run: npm run build
-      
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4.37.4
         with:


### PR DESCRIPTION
JavaScript/TypeScript does not require a build step for CodeQL analysis — the extractor reads source files directly. Removing the Node setup, `npm ci`, and `npm run build` steps which were unnecessary overhead and were causing the same Dependabot lock file failures as `ci.yml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the security analysis workflow by removing unnecessary setup, installation, and build steps.
  * Security scanning now proceeds directly to analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->