### PR TITLE
fix: validateFirst check catches PENDING/PROCESSING/PARTIALLY_AVAILABLE statuses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -333,6 +333,37 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
+    "node_modules/@commitlint/read/node_modules/conventional-commits-filter": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-6.0.1.tgz",
+      "integrity": "sha512-cs+LadpH7Kpw0M3k8wurk+sOVVDAENA0iK4OBOrkL94j5lEVYRJ4j3zd2bhY9qgzyrPqthdcYT3axzRN7AliMg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@commitlint/read/node_modules/conventional-commits-parser": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-7.1.2.tgz",
+      "integrity": "sha512-O+x4N2yH+ijvqWlIyTHsXTAP+algNWgGbjY2duCe8w2vUMvUB95cLRslCPfTMQyLAKlet3bhZTdu6ozn4M+QJQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@simple-libs/stream-utils": "^2.0.0",
+        "argue-cli": "^3.1.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
     "node_modules/@commitlint/resolve-extends": {
       "version": "21.2.0",
       "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-21.2.0.tgz",
@@ -2247,9 +2278,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.33",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.33.tgz",
-      "integrity": "sha512-+SwvkaiJtxsiPjhy9LivY/1m7UsNqCJetM1BrZl9A5DkQhlbHQDU730mMiDPWjnoCYOM8Chf3WrCJw27kNTPFQ==",
+      "version": "4.13.3",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.3.tgz",
+      "integrity": "sha512-r8AO2mYHoLxSHkgafNeC/BXyb2vWRxD3jem4Ts+ptav8oTG5FIRifAjuJEmZI4bSvvc2ns0GxmIYiZnHqN3mMw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -2460,9 +2491,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1731,7 +1731,7 @@ class OverseerrServer {
         };
       }
 
-      if (mediaInfo?.status === 5) { // AVAILABLE
+      if (mediaInfo?.status != null && [2, 3, 4, 5].includes(mediaInfo.status)) { // PENDING, PROCESSING, PARTIALLY_AVAILABLE, or AVAILABLE
         return {
           content: [
             {


### PR DESCRIPTION
## Summary

Fixes #147.

The `validateFirst` path in `request_media` was checking `mediaInfo?.status === 5` (AVAILABLE only), which missed statuses 2–4. If media was PENDING, PROCESSING, or PARTIALLY_AVAILABLE with no active requests, the server would attempt to place a duplicate request.

Fixed to `[2, 3, 4, 5].includes(mediaInfo.status)`, consistent with every other status check in the file.

Also includes patch-level `npm audit fix` for hono and js-yaml vulnerabilities.

## Tests

All 26 checks passed (19 functional + 5 HTTP + build).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media request validation to correctly handle media that is pending, processing, partially available, or available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->