### PR TITLE
test: add unit test layer for pure logic + wire into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
       - name: TypeScript Build
         run: npm run build
       
+      - name: Run unit tests
+        run: node --test --test-reporter=spec build/utils/__tests__/*.test.js
+      
       - name: Verify build output
         run: |
           test -f build/index.js || (echo "❌ build/index.js not found" && exit 1)

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   "scripts": {
     "build": "tsc && node -e \"require('fs').chmodSync('build/index.js', '755')\"",
     "watch": "tsc --watch",
+    "test": "npm run build && node --test --test-reporter=spec build/utils/__tests__/*.test.js",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {

--- a/src/utils/__tests__/mediaStatus.test.ts
+++ b/src/utils/__tests__/mediaStatus.test.ts
@@ -1,0 +1,67 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { isTracked, isFullyAvailable, label } from '../mediaStatus.js';
+
+// ── isTracked ────────────────────────────────────────────────────────────────
+
+test('isTracked: PENDING (2) is tracked', () => {
+  assert.equal(isTracked(2), true);
+});
+
+test('isTracked: PROCESSING (3) is tracked', () => {
+  assert.equal(isTracked(3), true);
+});
+
+test('isTracked: PARTIALLY_AVAILABLE (4) is tracked', () => {
+  assert.equal(isTracked(4), true);
+});
+
+test('isTracked: AVAILABLE (5) is tracked', () => {
+  assert.equal(isTracked(5), true);
+});
+
+test('isTracked: UNKNOWN (1) is not tracked', () => {
+  assert.equal(isTracked(1), false);
+});
+
+test('isTracked: DELETED (6) is not tracked', () => {
+  assert.equal(isTracked(6), false);
+});
+
+test('isTracked: 0 is not tracked', () => {
+  assert.equal(isTracked(0), false);
+});
+
+// ── isFullyAvailable ─────────────────────────────────────────────────────────
+
+test('isFullyAvailable: AVAILABLE (5) is fully available', () => {
+  assert.equal(isFullyAvailable(5), true);
+});
+
+test('isFullyAvailable: PARTIALLY_AVAILABLE (4) is not fully available', () => {
+  assert.equal(isFullyAvailable(4), false);
+});
+
+test('isFullyAvailable: PENDING (2) is not fully available', () => {
+  assert.equal(isFullyAvailable(2), false);
+});
+
+test('isFullyAvailable: PROCESSING (3) is not fully available', () => {
+  assert.equal(isFullyAvailable(3), false);
+});
+
+// ── label ────────────────────────────────────────────────────────────────────
+
+test('label: maps known status codes to strings', () => {
+  assert.equal(label(1), 'UNKNOWN');
+  assert.equal(label(2), 'PENDING');
+  assert.equal(label(3), 'PROCESSING');
+  assert.equal(label(4), 'PARTIALLY_AVAILABLE');
+  assert.equal(label(5), 'AVAILABLE');
+  assert.equal(label(6), 'DELETED');
+});
+
+test('label: returns UNKNOWN for unrecognised codes', () => {
+  assert.equal(label(99), 'UNKNOWN');
+  assert.equal(label(0), 'UNKNOWN');
+});

--- a/src/utils/__tests__/normalize.test.ts
+++ b/src/utils/__tests__/normalize.test.ts
@@ -1,0 +1,76 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { normalizeTitle, extractSeasonNumber } from '../normalize.js';
+
+// ── normalizeTitle ───────────────────────────────────────────────────────────
+
+test('normalizeTitle: removes S-notation seasons', () => {
+  assert.equal(normalizeTitle('My Hero Academia S7'), 'My Hero Academia');
+  assert.equal(normalizeTitle('Demon Slayer S4'), 'Demon Slayer');
+  assert.equal(normalizeTitle('Solo Leveling S2'), 'Solo Leveling');
+});
+
+test('normalizeTitle: removes Roman numeral seasons', () => {
+  assert.equal(normalizeTitle('Overlord IV'), 'Overlord');
+  assert.equal(normalizeTitle('Mob Psycho 100 III'), 'Mob Psycho 100');
+  assert.equal(normalizeTitle('Sword Art Online II'), 'Sword Art Online');
+});
+
+test('normalizeTitle: removes Season N patterns', () => {
+  assert.equal(normalizeTitle('My Hero Academia Season 7'), 'My Hero Academia');
+  assert.equal(normalizeTitle('Attack on Titan Season 4'), 'Attack on Titan');
+});
+
+test('normalizeTitle: removes Part/Cour patterns', () => {
+  assert.equal(normalizeTitle('Demon Slayer Part 2'), 'Demon Slayer');
+  assert.equal(normalizeTitle('Re:Zero Cour 2'), 'Re:Zero');
+});
+
+test('normalizeTitle: removes Final Season patterns', () => {
+  assert.equal(normalizeTitle('Attack on Titan The Final Season'), 'Attack on Titan');
+  assert.equal(normalizeTitle('My Hero Academia Final Season'), 'My Hero Academia');
+});
+
+test('normalizeTitle: preserves integral numbers in titles', () => {
+  assert.equal(normalizeTitle('Mob Psycho 100'), 'Mob Psycho 100');
+  assert.equal(normalizeTitle('86 Eighty-Six'), '86 Eighty-Six');
+});
+
+test('normalizeTitle: removes trailing year in parentheses', () => {
+  assert.equal(normalizeTitle('Dune (2024)'), 'Dune');
+  assert.equal(normalizeTitle('My Show S2 (2023)'), 'My Show');
+});
+
+test('normalizeTitle: leaves titles with no season indicators unchanged', () => {
+  assert.equal(normalizeTitle('Frieren: Beyond Journey\'s End'), 'Frieren: Beyond Journey\'s End');
+  assert.equal(normalizeTitle('Attack on Titan'), 'Attack on Titan');
+});
+
+// ── extractSeasonNumber ──────────────────────────────────────────────────────
+
+test('extractSeasonNumber: extracts from S-notation', () => {
+  assert.equal(extractSeasonNumber('My Hero Academia S7'), 7);
+  assert.equal(extractSeasonNumber('Demon Slayer S4'), 4);
+  assert.equal(extractSeasonNumber('Solo Leveling S2'), 2);
+});
+
+test('extractSeasonNumber: extracts Roman numerals', () => {
+  assert.equal(extractSeasonNumber('Overlord IV'), 4);
+  assert.equal(extractSeasonNumber('Mob Psycho 100 III'), 3);
+  assert.equal(extractSeasonNumber('Sword Art Online II'), 2);
+});
+
+test('extractSeasonNumber: extracts from Season N', () => {
+  assert.equal(extractSeasonNumber('Attack on Titan Season 4'), 4);
+  assert.equal(extractSeasonNumber('My Hero Academia Season 7'), 7);
+});
+
+test('extractSeasonNumber: extracts from Part N', () => {
+  assert.equal(extractSeasonNumber('Demon Slayer Part 2'), 2);
+});
+
+test('extractSeasonNumber: returns null when no season present', () => {
+  assert.equal(extractSeasonNumber('Frieren: Beyond Journey\'s End'), null);
+  assert.equal(extractSeasonNumber('Attack on Titan'), null);
+  assert.equal(extractSeasonNumber('Mob Psycho 100'), null);
+});

--- a/src/utils/mediaStatus.ts
+++ b/src/utils/mediaStatus.ts
@@ -1,0 +1,43 @@
+/**
+ * Media status vocabulary for Overseerr/Jellyseerr.
+ *
+ * Status codes returned by the Seerr API:
+ *   1 = UNKNOWN
+ *   2 = PENDING       — request submitted, waiting to be picked up
+ *   3 = PROCESSING    — Radarr/Sonarr is actively grabbing it
+ *   4 = PARTIALLY_AVAILABLE — some episodes present, more coming
+ *   5 = AVAILABLE     — fully in the library
+ *   6 = DELETED
+ */
+export const MEDIA_STATUS: Record<number, string> = {
+  1: 'UNKNOWN',
+  2: 'PENDING',
+  3: 'PROCESSING',
+  4: 'PARTIALLY_AVAILABLE',
+  5: 'AVAILABLE',
+  6: 'DELETED',
+};
+
+/**
+ * Returns true when media is tracked by the system —
+ * i.e. has been requested or is in the library in any state.
+ * Statuses 2–5 all count; 1 (UNKNOWN) and 6 (DELETED) do not.
+ */
+export function isTracked(status: number): boolean {
+  return [2, 3, 4, 5].includes(status);
+}
+
+/**
+ * Returns true only when media is fully available in the library (status 5).
+ */
+export function isFullyAvailable(status: number): boolean {
+  return status === 5;
+}
+
+/**
+ * Maps a numeric status code to its string label.
+ * Returns 'UNKNOWN' for unrecognised codes.
+ */
+export function label(status: number): string {
+  return MEDIA_STATUS[status] ?? 'UNKNOWN';
+}

--- a/src/utils/normalize.ts
+++ b/src/utils/normalize.ts
@@ -21,8 +21,7 @@ export function normalizeTitle(title: string): string {
     /\s*Part\s+\d+/gi,
     /\s*Cour\s+\d+/gi,
     /\s*\d+(?:st|nd|rd|th)\s+Season/gi,
-    /\s*Final\s+Season/gi,
-    /\s*The\s+Final\s+Season/gi,
+    /\s*(?:The\s+)?Final\s+Season/gi,
     /\s*\(Season\s+\d+\)/gi,
     /\s*\(\d+(?:st|nd|rd|th)\s+Season\)/gi,
   ];


### PR DESCRIPTION
## Summary

Closes #149.

Adds a fast unit test layer that runs on every PR in CI — no live Overseerr instance needed.

## What's in this PR

**New module: `src/utils/mediaStatus.ts`**
Extracts the status vocabulary (2=PENDING…5=AVAILABLE) into a proper module with `isTracked()`, `isFullyAvailable()`, and `label()`. Provides the named predicates that code rabbit flagged as missing from the #147 fix.

**26 unit tests** across two files:
- `mediaStatus.test.ts` — 13 tests covering all status predicate cases
- `normalize.test.ts` — 13 tests covering S-notation, Roman numerals, Season N, Part/Cour, Final Season patterns

**Bug found and fixed by the tests**
`normalizeTitle('Attack on Titan The Final Season')` was returning `'Attack on Titan The'` — the `Final Season` pattern stripped the suffix before the `The Final Season` pattern could run. Fixed by collapsing both into `(?:The\s+)?Final\s+Season`.

**CI**: unit tests now run on every PR after the TypeScript build — zero credentials needed.

**Test skill**: Test 20 added — validateFirst blocks duplicate request on already-available media.

## Tests

```
26 pass, 0 fail — npm test
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added media status labels and utilities for identifying tracked and fully available media.
  * Added fallback labeling for unrecognized media statuses.

* **Bug Fixes**
  * Improved title normalization for titles containing “Final Season” or “The Final Season.”

* **Tests**
  * Added comprehensive coverage for media statuses and title normalization.
  * Added an npm test command and integrated automated tests into the build workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->