### PR TITLE
refactor: extract classifyAvailability from handleDedupeMode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,8 @@ import { SeerrApiClient } from './utils/seerrClient.js';
 import { VERSION } from './version.js';
 import { normalizeTitle, extractSeasonNumber, inferExpectedMediaType, selectBestMatch } from './utils/normalize.js';
 import { batchWithRetry } from './utils/retry.js';
+import { classifyAvailability } from './utils/availabilityClassifier.js';
+import { isTracked } from './utils/mediaStatus.js';
 import {
   SearchResult,
   SearchResultItem,
@@ -24,6 +26,7 @@ import {
   ManageRequestsArgs,
   GetDetailsArgs,
   DedupeResult,
+  ReasonCode,
   CompactMediaResult,
   MediaInfo,
   DedupeDetails,
@@ -802,562 +805,145 @@ class OverseerrServer {
     const dedupeResults: DedupeResult[] = [];
     const autoRequestQueue: Array<{ mediaType: 'movie' | 'tv'; mediaId: number; seasons?: number[] | 'all' }> = [];
 
+    /**
+     * Checks whether a season number exists in media details.
+     * Prefers the seasons array (authoritative); falls back to numberOfSeasons.
+     */
+    const doesSeasonExist = (det: MediaDetails, sNum: number): boolean => {
+      if (det.seasons?.length) {
+        return det.seasons.some(s => s.seasonNumber === sNum);
+      }
+      if (det.numberOfSeasons !== undefined) {
+        return sNum <= det.numberOfSeasons;
+      }
+      return false;
+    };
+
     const processedTitles = await batchWithRetry(
       titles,
       async (originalTitle) => {
-        // Normalize title if requested
         const searchTitle = autoNormalize ? normalizeTitle(originalTitle) : originalTitle;
         const seasonNumber = extractSeasonNumber(originalTitle);
 
-        // Search for the title
-        let searchResult = await this.client.search(searchTitle, {
+        // ── 1. Search ──────────────────────────────────────────────────────────
+        const searchResult = await this.client.search(searchTitle, {
           page: 1,
           language: args.language || 'en',
         });
 
-        // If no results, it's NOT_FOUND — treated as blocked (cannot be requested)
         if (!searchResult.results || searchResult.results.length === 0) {
-          // Not found since NOT_FOUND items cannot be requested
-          const baseResult: DedupeResult = {
+          return {
             title: originalTitle,
             id: 0,
-            mediaType: undefined,  // Unknown since not found
+            mediaType: undefined,
             status: 'blocked' as const,
-            reasonCode: 'NOT_FOUND',
+            reasonCode: 'NOT_FOUND' as ReasonCode,
             isActionable: false,
             note: 'Not found in TMDB',
-          };
-          // No enrichment for not found items
-          return baseResult;
+          } satisfies DedupeResult;
         }
 
-        // Smart result selection with media type validation
+        // ── 2. Match ───────────────────────────────────────────────────────────
         const expectedType = inferExpectedMediaType(originalTitle);
         const selection = selectBestMatch(searchResult.results, expectedType, searchTitle);
         let bestMatch = selection.match;
-        let alternates = selection.alternates;
-        
-        // Log low confidence matches for debugging
+        const alternates = selection.alternates;
+
         if (selection.confidence === 'low') {
           console.error(`[WARN] Low confidence match for "${originalTitle}": expected ${expectedType}, got ${bestMatch.mediaType} (${bestMatch.title || bestMatch.name})`);
         }
-        
-        // For season-specific queries, validate season number exists in matched series
-        if (seasonNumber && bestMatch.mediaType === 'tv') {
-          // Fetch details to check numberOfSeasons
-          let details = await this.client.getMediaDetails('tv', bestMatch.id);
-          
-          /**
-           * Helper: check if a season number exists in media details
-           * Prefers the seasons array (authoritative), falls back to numberOfSeasons for safety
-           */
-          const doesSeasonExist = (det: MediaDetails, sNum: number): boolean => {
-            if (det.seasons?.length) {
-              return det.seasons.some(s => s.seasonNumber === sNum);
-            }
-            if (det.numberOfSeasons !== undefined) {
-              return sNum <= det.numberOfSeasons;
-            }
-            return false;
-          };
 
-          // Validate: if requested season does not exist, try alternates
+        // ── 3. Fetch details ───────────────────────────────────────────────────
+        let details = await this.client.getMediaDetails(
+          bestMatch.mediaType as 'movie' | 'tv',
+          bestMatch.id
+        );
+
+        // ── 4. Season existence check (SEASON_NOT_FOUND — orchestrator concern) ─
+        if (seasonNumber && bestMatch.mediaType === 'tv') {
           if (!doesSeasonExist(details, seasonNumber)) {
             console.error(`[WARN] Season ${seasonNumber} not found in seasons data for "${bestMatch.title || bestMatch.name}". Trying alternates...`);
-            
-            // Try each alternate
             let foundValid = false;
             for (const alternate of alternates) {
               if (alternate.mediaType !== 'tv') continue;
-              
-              let altDetails = await this.client.getMediaDetails('tv', alternate.id);
-              
-              // Use same helper for alternate validation
+              const altDetails = await this.client.getMediaDetails('tv', alternate.id);
               if (doesSeasonExist(altDetails, seasonNumber)) {
                 console.error(`[INFO] Found valid alternate: "${alternate.title || alternate.name}" for season ${seasonNumber}`);
                 bestMatch = alternate;
+                details = altDetails;
                 foundValid = true;
                 break;
               }
             }
-            
-            // If no valid alternate found, return blocked with the original show ID
-             // indicating the season is not available for any matching series
-             if (!foundValid) {
-               const baseResult: DedupeResult = {
-                 title: originalTitle,
-                 id: bestMatch.id,
-                 mediaType: 'tv',
-                 status: 'blocked' as const,
-                 reason: `Season ${seasonNumber} not available - show exists but season does not`,
-                 reasonCode: 'SEASON_NOT_FOUND',
-                 isActionable: false,
-                 franchiseInfo: `Season ${seasonNumber} not found in "${bestMatch.title || bestMatch.name}"`,
-               };
-              if (requestedFields.length > 0) {
-                return this.enrichDedupeResult(
-                  baseResult,
-                  { mediaType: 'tv', id: bestMatch.id },
-                  details,
-                  requestedFields,
-                  seasonNumber,
-                  includeSeason
-                );
-              }
-              return baseResult;
+            if (!foundValid) {
+              const baseResult: DedupeResult = {
+                title: originalTitle,
+                id: bestMatch.id,
+                mediaType: 'tv',
+                status: 'blocked' as const,
+                reason: `Season ${seasonNumber} not available - show exists but season does not`,
+                reasonCode: 'SEASON_NOT_FOUND',
+                isActionable: false,
+                franchiseInfo: `Season ${seasonNumber} not found in "${bestMatch.title || bestMatch.name}"`,
+              };
+              return this.enrichDedupeResult(baseResult, { mediaType: 'tv', id: bestMatch.id }, details, requestedFields, seasonNumber, includeSeason);
             }
           }
         }
-        
-        // Check if it's TV and we need details for season checking
-        if (bestMatch.mediaType === 'tv') {
-          let details = await this.client.getMediaDetails('tv', bestMatch.id);
 
-          // Get media info for status checking
-          const mediaInfo = details.mediaInfo;
-          
-          // CASE 1: Specific season mentioned in title
-          if (seasonNumber) {
-            // Check if this specific season is in library (PENDING, PROCESSING, PARTIALLY_AVAILABLE, or AVAILABLE)
-            // Do NOT block: UNKNOWN(1), DELETED(6), or missing
-            const targetSeasonInfo = mediaInfo?.seasons?.find(s => s.seasonNumber === seasonNumber);
-            if (targetSeasonInfo && [2, 3, 4, 5].includes(targetSeasonInfo.status)) {
-              const statusStr = this.getMediaStatusString(targetSeasonInfo.status);
-              const baseResult: DedupeResult = {
-                title: originalTitle,
-                id: bestMatch.id,
-                mediaType: 'tv',
-                status: 'blocked' as const,
-                reason: `Season ${seasonNumber} is ${statusStr.toLowerCase()}`,
-                reasonCode: 'SEASON_AVAILABLE',
-                isActionable: false,
-                franchiseInfo: `Season ${seasonNumber} of ${details.name || bestMatch.name}`,
-              };
-              if (requestedFields.length > 0) {
-                return this.enrichDedupeResult(
-                  baseResult,
-                  { mediaType: 'tv', id: bestMatch.id },
-                  details,
-                  requestedFields,
-                  seasonNumber,
-                  includeSeason
-                );
-              }
-              return baseResult;
-            }
-            
-            // Check if this specific season is requested
-            const seasonRequested = mediaInfo?.requests?.some(req =>
-              req.media.seasons?.some(s => s.seasonNumber === seasonNumber)
-            );
-            if (seasonRequested) {
-              const baseResult: DedupeResult = {
-                title: originalTitle,
-                id: bestMatch.id,
-                mediaType: 'tv',
-                status: 'blocked' as const,
-                reason: `Season ${seasonNumber} is already requested`,
-                reasonCode: 'SEASON_REQUESTED',
-                isActionable: false,
-                franchiseInfo: `Season ${seasonNumber} of ${details.name || bestMatch.name}`,
-              };
-              if (requestedFields.length > 0) {
-                return this.enrichDedupeResult(
-                  baseResult,
-                  { mediaType: 'tv', id: bestMatch.id },
-                  details,
-                  requestedFields,
-                  seasonNumber,
-                  includeSeason
-                );
-              }
-              return baseResult;
-            }
-            
-            // Specific season not in library/requested - it's a pass
-            const baseResult: DedupeResult = {
-              title: originalTitle,
-              id: bestMatch.id,
-              mediaType: 'tv',
-              status: 'pass' as const,
-              reasonCode: 'AVAILABLE_FOR_REQUEST',
-              isActionable: true,
-              franchiseInfo: `Season ${seasonNumber} of ${details.name || bestMatch.name}`,
-            };
-            // Auto-add enhanced details if requested
-            if (requestedFields.length > 0) {
-              return this.enrichDedupeResult(
-                baseResult,
-                { mediaType: 'tv', id: bestMatch.id },
-                details,
-                requestedFields,
-                seasonNumber,
-                includeSeason
-              );
-            }
-            return baseResult;
-          }
-          
-          // CASE 2: No specific season mentioned - check base series availability
-          // BUG FIX: Check show-level status FIRST before checking individual seasons
-          // This catches shows marked as AVAILABLE at show level even without complete season data
-          if (mediaInfo && [5].includes(mediaInfo.status)) {
-            const baseResult: DedupeResult = {
-              title: originalTitle,
-              id: bestMatch.id,
-              mediaType: 'tv',
-              status: 'blocked' as const,
-              reason: `Already in library (show-level)`,
-              reasonCode: 'ALREADY_AVAILABLE',
-              isActionable: false,
-              franchiseInfo: `${details.name || bestMatch.name}`,
-            };
-            if (requestedFields.length > 0) {
-              return this.enrichDedupeResult(baseResult, { mediaType: 'tv', id: bestMatch.id }, details, requestedFields, null, includeSeason);
-            }
-            return baseResult;
-          }
-          
-          // Check if there are show-level requests (not season-specific)
-          if (mediaInfo?.requests && mediaInfo.requests.length > 0) {
-            const hasShowLevelRequest = mediaInfo.requests.some(req =>
-              !req.media.seasons || req.media.seasons.length === 0
-            );
-            if (hasShowLevelRequest) {
-              const baseResult: DedupeResult = {
-                title: originalTitle,
-                id: bestMatch.id,
-                mediaType: 'tv',
-                status: 'blocked' as const,
-                reason: 'Already requested (show-level)',
-                reasonCode: 'ALREADY_REQUESTED',
-                isActionable: false,
-                franchiseInfo: `${details.name || bestMatch.name}`,
-              };
-              if (requestedFields.length > 0) {
-                return this.enrichDedupeResult(baseResult, { mediaType: 'tv', id: bestMatch.id }, details, requestedFields, null, includeSeason);
-              }
-              return baseResult;
-            }
-          }
-          
-          // Now check individual seasons
-          const regularSeasons = details.seasons?.filter(s => s.seasonNumber > 0) || [];
-          
-          if (regularSeasons.length > 0) {
-            // Check if ALL regular seasons are in library (statuses 2-5)
-            const allSeasonsAvailable = regularSeasons.every(season => {
-              const seasonInfo = mediaInfo?.seasons?.find(s => s.seasonNumber === season.seasonNumber);
-              return seasonInfo && [2, 3, 4, 5].includes(seasonInfo.status);
-            });
-            
-            if (allSeasonsAvailable && mediaInfo?.seasons && mediaInfo.seasons.length > 0) {
-              const availableSeasons = mediaInfo.seasons.filter(s => s.seasonNumber > 0 && [2, 3, 4, 5].includes(s.status)).map(s => s.seasonNumber).sort((a, b) => a - b);
-              const baseResult: DedupeResult = {
-                title: originalTitle,
-                id: bestMatch.id,
-                mediaType: 'tv',
-                status: 'blocked' as const,
-                reason: `All regular seasons already in library (${availableSeasons.join(', ')})`,
-                reasonCode: 'ALREADY_AVAILABLE',
-                isActionable: false,
-                franchiseInfo: `${details.name || bestMatch.name} - All ${availableSeasons.length} seasons in library (S${availableSeasons.join(', S')})`,
-              };
-              if (requestedFields.length > 0) {
-                return this.enrichDedupeResult(baseResult, { mediaType: 'tv', id: bestMatch.id }, details, requestedFields, null, includeSeason);
-              }
-              return baseResult;
-            }
-            
-            // Check if ALL regular seasons are requested
-            const allSeasonsRequested = regularSeasons.every(season => {
-              return mediaInfo?.requests?.some(req =>
-                req.media.seasons?.some(s => s.seasonNumber === season.seasonNumber)
-              );
-            });
-            
-            if (allSeasonsRequested && mediaInfo?.requests && mediaInfo.requests.length > 0) {
-              const requestedSeasons = regularSeasons.filter(season =>
-                mediaInfo.requests?.some(req => req.media.seasons?.some(s => s.seasonNumber === season.seasonNumber))
-              ).map(s => s.seasonNumber).sort((a, b) => a - b);
-              const baseResult: DedupeResult = {
-                title: originalTitle,
-                id: bestMatch.id,
-                mediaType: 'tv',
-                status: 'blocked' as const,
-                reason: `All regular seasons already requested (${requestedSeasons.join(', ')})`,
-                reasonCode: 'ALREADY_REQUESTED',
-                isActionable: false,
-                franchiseInfo: `${details.name || bestMatch.name} - All ${requestedSeasons.length} seasons requested (S${requestedSeasons.join(', S')})`,
-              };
-              if (requestedFields.length > 0) {
-                return this.enrichDedupeResult(baseResult, { mediaType: 'tv', id: bestMatch.id }, details, requestedFields, null, includeSeason);
-              }
-              return baseResult;
-            }
-            
-            // Partial availability/requests - check enhanced franchise info
-            let availableSeasons = mediaInfo?.seasons?.filter(s => s.seasonNumber > 0 && [2, 3, 4, 5].includes(s.status)).map(s => s.seasonNumber).sort((a, b) => a - b) || [];
-            let requestedSeasons = regularSeasons.filter(season =>
-              mediaInfo?.requests?.some(req => req.media.seasons?.some(s => s.seasonNumber === season.seasonNumber))
-            ).map(s => s.seasonNumber).sort((a, b) => a - b);
-            
-            // Build enhanced franchise info
-            let franchiseInfo = `${details.name || bestMatch.name}`;
-            if (availableSeasons.length > 0 || requestedSeasons.length > 0) {
-              const statusParts = [];
-              if (availableSeasons.length > 0) {
-                statusParts.push(`${availableSeasons.length} in library (S${availableSeasons.join(', S')})`);
-              }
-              if (requestedSeasons.length > 0) {
-                statusParts.push(`${requestedSeasons.length} requested (S${requestedSeasons.join(', S')})`);
-              }
-              franchiseInfo += ` - ${statusParts.join(', ')}`;
-            }
+        // ── 5. Classify ────────────────────────────────────────────────────────
+        const mediaType = bestMatch.mediaType as 'movie' | 'tv';
+        const showSeasons = mediaType === 'tv'
+          ? details.seasons?.filter(s => s.seasonNumber > 0)
+          : undefined;
+        const requestedSeasons = args.requestOptions?.seasons && args.requestOptions.seasons !== 'all'
+          ? (args.requestOptions.seasons as number[])
+          : undefined;
 
-            // If requestOptions.seasons provided as specific numbers, check if ALL of those
-            // seasons are already covered (in library or already requested) — if so, block
-            if (args.requestOptions?.seasons && args.requestOptions.seasons !== 'all') {
-              const targetSeasons = args.requestOptions.seasons as number[];
+        const classified = classifyAvailability(details.mediaInfo, mediaType, seasonNumber, {
+          showSeasons,
+          requestedSeasons,
+        });
 
-              if (targetSeasons.length === 0) {
-                // Empty seasons array — no specific seasons to check, fall through to pass
-              } else {
-                const allTargetAvailable = targetSeasons.every(sNum =>
-                  (mediaInfo?.seasons?.some(si => si.seasonNumber === sNum && [2, 3, 4, 5].includes(si.status)) || false)
-                );
-                const allTargetRequested = targetSeasons.every(sNum =>
-                  (mediaInfo?.requests?.some(req => req.media.seasons?.some(s => s.seasonNumber === sNum)) || false)
-                );
-                const allTargetCovered = targetSeasons.every(sNum =>
-                  (mediaInfo?.seasons?.some(si => si.seasonNumber === sNum && [2, 3, 4, 5].includes(si.status)) || false) ||
-                  (mediaInfo?.requests?.some(req => req.media.seasons?.some(s => s.seasonNumber === sNum)) || false)
-                );
+        // ── 6. Build franchiseInfo (orchestrator assembles display string) ─────
+        const showName = details.name || details.title || bestMatch.name || bestMatch.title || '';
+        let franchiseInfo: string | undefined;
 
-                if (allTargetAvailable) {
-                   const baseResult: DedupeResult = {
-                     title: originalTitle,
-                     id: bestMatch.id,
-                     mediaType: 'tv',
-                     status: 'blocked' as const,
-                     reason: `Requested season(s) already in library (${targetSeasons.join(', ')})`,
-                     reasonCode: 'SEASON_AVAILABLE',
-                     isActionable: false,
-                     franchiseInfo: franchiseInfo,
-                   };
-                  if (requestedFields.length > 0) {
-                    return this.enrichDedupeResult(baseResult, { mediaType: 'tv', id: bestMatch.id }, details, requestedFields, null, includeSeason);
-                  }
-                  return baseResult;
-                }
+        if (mediaType === 'tv' && showName) {
+          if (seasonNumber !== null) {
+            franchiseInfo = `Season ${seasonNumber} of ${showName}`;
+          } else {
+            const availableNums = details.mediaInfo?.seasons
+              ?.filter(s => s.seasonNumber > 0 && isTracked(s.status))
+              .map(s => s.seasonNumber)
+              .sort((a, b) => a - b) ?? [];
+            const requestedNums = details.mediaInfo?.requests
+              ?.flatMap(req => req.media.seasons?.filter(s => s.seasonNumber > 0).map(s => s.seasonNumber) ?? [])
+              .filter((n, i, arr) => arr.indexOf(n) === i)
+              .sort((a, b) => a - b) ?? [];
 
-                if (allTargetRequested) {
-                  const baseResult: DedupeResult = {
-                    title: originalTitle,
-                    id: bestMatch.id,
-                    mediaType: 'tv',
-                    status: 'blocked' as const,
-                    reason: `Requested season(s) already requested (${targetSeasons.join(', ')})`,
-                    reasonCode: 'SEASON_REQUESTED',
-                    isActionable: false,
-                    franchiseInfo: franchiseInfo,
-                  };
-                  if (requestedFields.length > 0) {
-                    return this.enrichDedupeResult(baseResult, { mediaType: 'tv', id: bestMatch.id }, details, requestedFields, null, includeSeason);
-                  }
-                  return baseResult;
-                }
-
-                if (allTargetCovered) {
-                  const baseResult: DedupeResult = {
-                    title: originalTitle,
-                    id: bestMatch.id,
-                    mediaType: 'tv',
-                    status: 'blocked' as const,
-                    reason: `Requested season(s) already in library or requested (${targetSeasons.join(', ')})`,
-                    reasonCode: 'SEASON_REQUESTED',
-                    isActionable: false,
-                    franchiseInfo: franchiseInfo,
-                  };
-                  if (requestedFields.length > 0) {
-                    return this.enrichDedupeResult(baseResult, { mediaType: 'tv', id: bestMatch.id }, details, requestedFields, null, includeSeason);
-                  }
-                  return baseResult;
-                }
-              }
-            }
-
-            // Fall through — at least one requested season is not yet available or requested
-            // Some seasons in library/requested, but not all - it's a pass
-            const baseResult: DedupeResult = {
-              title: originalTitle,
-              id: bestMatch.id,
-              mediaType: 'tv',
-              status: 'pass' as const,
-              reasonCode: 'AVAILABLE_FOR_REQUEST',
-              isActionable: true,
-              franchiseInfo: franchiseInfo,
-            };
-            // Auto-add enhanced details if requested
-            if (requestedFields.length > 0) {
-              return this.enrichDedupeResult(baseResult, { mediaType: 'tv', id: bestMatch.id }, details, requestedFields, null, includeSeason);
-            }
-            return baseResult;
+            franchiseInfo = showName;
+            const parts: string[] = [];
+            if (availableNums.length > 0) parts.push(`${availableNums.length} in library (S${availableNums.join(', S')})`);
+            if (requestedNums.length > 0) parts.push(`${requestedNums.length} requested (S${requestedNums.join(', S')})`);
+            if (parts.length > 0) franchiseInfo += ` - ${parts.join(', ')}`;
           }
-          
-          // Fallback: No seasons info available, check overall status
-          if (mediaInfo && [2, 3, 4, 5].includes(mediaInfo.status)) {
-            const statusStr = this.getMediaStatusString(mediaInfo.status);
-            const baseResult: DedupeResult = {
-              title: originalTitle,
-              id: bestMatch.id,
-              mediaType: 'tv',
-              status: 'blocked' as const,
-              reason: `Already in library (${statusStr.toLowerCase()})`,
-              reasonCode: 'ALREADY_AVAILABLE',
-              isActionable: false,
-            };
-            // Enrich if details requested
-            if (requestedFields.length > 0) {
-              return this.enrichDedupeResult(
-                baseResult,
-                { mediaType: 'tv', id: bestMatch.id },
-                details,
-                requestedFields,
-                null,
-                includeSeason
-              );
-            }
-            return baseResult;
-          }
-          
-          if (mediaInfo?.requests && mediaInfo.requests.length > 0) {
-            const baseResult: DedupeResult = {
-              title: originalTitle,
-              id: bestMatch.id,
-              mediaType: 'tv',
-              status: 'blocked' as const,
-              reason: 'Already requested',
-              reasonCode: 'ALREADY_REQUESTED',
-              isActionable: false,
-            };
-            // Enrich if details requested
-            if (requestedFields.length > 0) {
-              return this.enrichDedupeResult(
-                baseResult,
-                { mediaType: 'tv', id: bestMatch.id },
-                details,
-                requestedFields,
-                null,
-                includeSeason
-              );
-            }
-            return baseResult;
-          }
-          
-          // Not requested - it's a pass
-          const baseResult: DedupeResult = {
-            title: originalTitle,
-            id: bestMatch.id,
-            mediaType: 'tv',
-            status: 'pass' as const,
-            reasonCode: 'AVAILABLE_FOR_REQUEST',
-            isActionable: true,
-          };
-          
-          // Enrich if details requested
-          if (requestedFields.length > 0) {
-            return this.enrichDedupeResult(
-              baseResult,
-              { mediaType: 'tv', id: bestMatch.id },
-              details,
-              requestedFields,
-              null,
-              includeSeason
-            );
-          }
-          return baseResult;
-        } else {
-          // Movie - simpler check
-          let details = await this.client.getMediaDetails('movie', bestMatch.id);
-
-          const mediaInfo = details.mediaInfo;
-          if (mediaInfo && mediaInfo.status) {
-            const statusStr = this.getMediaStatusString(mediaInfo.status);
-            
-            // Check if movie is in library (statuses 2-5)
-            if ([2, 3, 4, 5].includes(mediaInfo.status)) {
-              const baseResult: DedupeResult = {
-                title: originalTitle,
-                id: bestMatch.id,
-                mediaType: 'movie',
-                status: 'blocked' as const,
-                reason: `Already in library (${statusStr.toLowerCase()})`,
-                reasonCode: 'ALREADY_AVAILABLE',
-                isActionable: false,
-              };
-              // Enrich if details requested
-              if (requestedFields.length > 0) {
-                return this.enrichDedupeResult(
-                  baseResult,
-                  { mediaType: 'movie', id: bestMatch.id },
-                  details,
-                  requestedFields,
-                  null,
-                  includeSeason
-                );
-              }
-              return baseResult;
-            }
-            
-            if (mediaInfo.requests && mediaInfo.requests.length > 0) {
-              const baseResult: DedupeResult = {
-                title: originalTitle,
-                id: bestMatch.id,
-                mediaType: 'movie',
-                status: 'blocked' as const,
-                reason: 'Already requested',
-                reasonCode: 'ALREADY_REQUESTED',
-                isActionable: false,
-              };
-              // Enrich if details requested
-              if (requestedFields.length > 0) {
-                return this.enrichDedupeResult(
-                  baseResult,
-                  { mediaType: 'movie', id: bestMatch.id },
-                  details,
-                  requestedFields,
-                  null,
-                  includeSeason
-                );
-              }
-              return baseResult;
-            }
-          }
-          
-          // Not requested - it's a pass
-          const baseResult: DedupeResult = {
-            title: originalTitle,
-            id: bestMatch.id,
-            mediaType: 'movie',
-            status: 'pass' as const,
-            reasonCode: 'AVAILABLE_FOR_REQUEST',
-            isActionable: true,
-          };
-          
-          // Enrich if details requested
-          if (requestedFields.length > 0) {
-            return this.enrichDedupeResult(
-              baseResult,
-              { mediaType: 'movie', id: bestMatch.id },
-              details,
-              requestedFields,
-              null,
-              includeSeason
-            );
-          }
-          return baseResult;
         }
+
+        // ── 7. Build base result ───────────────────────────────────────────────
+        const baseResult: DedupeResult = {
+          title: originalTitle,
+          id: bestMatch.id,
+          mediaType,
+          status: classified.status,
+          reasonCode: classified.reasonCode,
+          isActionable: classified.status === 'pass',
+          ...(classified.reason !== undefined ? { reason: classified.reason } : {}),
+          ...(franchiseInfo !== undefined ? { franchiseInfo } : {}),
+        };
+
+        // ── 8. Enrich (unconditional — no-op when requestedFields is empty) ────
+        return this.enrichDedupeResult(baseResult, { mediaType, id: bestMatch.id }, details, requestedFields, seasonNumber, includeSeason);
       }
     );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,8 +32,6 @@ import {
   DedupeDetails,
   GetServicesArgs,
   GetServiceDetailsArgs,
-  ServiceConfig,
-  ServiceDetailsResponse,
 } from './types.js';
 
 // Field mapping for includeDetails feature

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,8 +14,7 @@ import { SeerrApiClient } from './utils/seerrClient.js';
 import { VERSION } from './version.js';
 import { normalizeTitle, extractSeasonNumber, inferExpectedMediaType, selectBestMatch } from './utils/normalize.js';
 import { batchWithRetry } from './utils/retry.js';
-import { classifyAvailability } from './utils/availabilityClassifier.js';
-import { isTracked } from './utils/mediaStatus.js';
+import { classifyAvailability, trackedSeasonNumbers } from './utils/availabilityClassifier.js';
 import {
   SearchResult,
   SearchResultItem,
@@ -862,8 +861,8 @@ class OverseerrServer {
           if (!doesSeasonExist(details, seasonNumber)) {
             console.error(`[WARN] Season ${seasonNumber} not found in seasons data for "${bestMatch.title || bestMatch.name}". Trying alternates...`);
             let foundValid = false;
-            for (const alternate of alternates) {
-              if (alternate.mediaType !== 'tv') continue;
+            const tvAlternates = alternates.filter(a => a.mediaType === 'tv').slice(0, 3);
+            for (const alternate of tvAlternates) {
               const altDetails = await this.client.getMediaDetails('tv', alternate.id);
               if (doesSeasonExist(altDetails, seasonNumber)) {
                 console.error(`[INFO] Found valid alternate: "${alternate.title || alternate.name}" for season ${seasonNumber}`);
@@ -911,10 +910,7 @@ class OverseerrServer {
           if (seasonNumber !== null) {
             franchiseInfo = `Season ${seasonNumber} of ${showName}`;
           } else {
-            const availableNums = details.mediaInfo?.seasons
-              ?.filter(s => s.seasonNumber > 0 && isTracked(s.status))
-              .map(s => s.seasonNumber)
-              .sort((a, b) => a - b) ?? [];
+            const availableNums = details.mediaInfo ? trackedSeasonNumbers(details.mediaInfo) : [];
             const requestedNums = details.mediaInfo?.requests
               ?.flatMap(req => req.media.seasons?.filter(s => s.seasonNumber > 0).map(s => s.seasonNumber) ?? [])
               .filter((n, i, arr) => arr.indexOf(n) === i)

--- a/src/types.ts
+++ b/src/types.ts
@@ -212,12 +212,21 @@ export interface ServiceDetailsResponse {
 }
 
 // Tool output types
+export type ReasonCode =
+  | 'NOT_FOUND'
+  | 'ALREADY_AVAILABLE'
+  | 'ALREADY_REQUESTED'
+  | 'SEASON_AVAILABLE'
+  | 'SEASON_REQUESTED'
+  | 'SEASON_NOT_FOUND'
+  | 'AVAILABLE_FOR_REQUEST';
+
 export interface DedupeResult {
   title: string;
   id: number;
   mediaType?: 'movie' | 'tv';  // Added to track type for autoRequest
   status: 'pass' | 'blocked';
-  reasonCode: 'NOT_FOUND' | 'ALREADY_AVAILABLE' | 'ALREADY_REQUESTED' | 'SEASON_AVAILABLE' | 'SEASON_REQUESTED' | 'SEASON_NOT_FOUND' | 'AVAILABLE_FOR_REQUEST';
+  reasonCode: ReasonCode;
   isActionable: boolean;
   reason?: string;
   franchiseInfo?: string;

--- a/src/utils/__tests__/availabilityClassifier.test.ts
+++ b/src/utils/__tests__/availabilityClassifier.test.ts
@@ -130,6 +130,25 @@ test('tv no season: show pending (status 2) → ALREADY_AVAILABLE', () => {
   assert.equal(result.reasonCode, 'ALREADY_AVAILABLE');
 });
 
+test('tv no season: partially available show (status 4) + untracked requestedSeason → AVAILABLE_FOR_REQUEST', () => {
+  // Regression: show-level isTracked(4) must not block when explicit requestedSeasons
+  // are provided and the target season is not yet tracked.
+  const result = classifyAvailability(
+    makeMediaInfo({
+      status: 4,
+      seasons: [{ id: 1, seasonNumber: 1, status: 5, createdAt: '', updatedAt: '' }],
+    }),
+    'tv',
+    null,
+    {
+      showSeasons: [{ seasonNumber: 1 }, { seasonNumber: 2 }],
+      requestedSeasons: [2],
+    }
+  );
+  assert.equal(result.status, 'pass');
+  assert.equal(result.reasonCode, 'AVAILABLE_FOR_REQUEST');
+});
+
 test('tv no season: show-level request (no seasons on request) → ALREADY_REQUESTED', () => {
   const result = classifyAvailability(
     makeMediaInfo({ requests: [makeRequest(/* no seasons */)] }),

--- a/src/utils/__tests__/availabilityClassifier.test.ts
+++ b/src/utils/__tests__/availabilityClassifier.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { classifyAvailability } from '../availabilityClassifier.js';
-import type { MediaInfo } from '../../types.js';
+import type { MediaInfo, MediaRequest } from '../../types.js';
 
 // ── Fixtures ─────────────────────────────────────────────────────────────────
 
@@ -16,7 +16,7 @@ function makeMediaInfo(overrides: Partial<MediaInfo> = {}): MediaInfo {
   };
 }
 
-function makeRequest(seasonNumbers?: number[]) {
+function makeRequest(seasonNumbers?: number[]): MediaRequest {
   return {
     id: 99,
     status: 2,
@@ -257,4 +257,25 @@ test('tv + seasonNumber SEASON_AVAILABLE reason mentions season number', () => {
     4
   );
   assert.ok(result.reason?.includes('4'), `expected "4" in "${result.reason}"`);
+});
+
+// ── no-showSeasons fallback ───────────────────────────────────────────────────
+
+test('tv no season, no showSeasons, has season-scoped request → ALREADY_REQUESTED', () => {
+  // When showSeasons is omitted the classifier falls back to checking requests directly.
+  // A populated requests array (with season scope) should block as ALREADY_REQUESTED.
+  const result = classifyAvailability(
+    makeMediaInfo({ requests: [makeRequest([1])] }),
+    'tv',
+    null
+    // options omitted — no showSeasons
+  );
+  assert.equal(result.status, 'blocked');
+  assert.equal(result.reasonCode, 'ALREADY_REQUESTED');
+});
+
+test('tv no season, no showSeasons, no requests → AVAILABLE_FOR_REQUEST', () => {
+  const result = classifyAvailability(makeMediaInfo(), 'tv', null);
+  assert.equal(result.status, 'pass');
+  assert.equal(result.reasonCode, 'AVAILABLE_FOR_REQUEST');
 });

--- a/src/utils/__tests__/availabilityClassifier.test.ts
+++ b/src/utils/__tests__/availabilityClassifier.test.ts
@@ -1,0 +1,260 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { classifyAvailability } from '../availabilityClassifier.js';
+import type { MediaInfo } from '../../types.js';
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+function makeMediaInfo(overrides: Partial<MediaInfo> = {}): MediaInfo {
+  return {
+    id: 1,
+    tmdbId: 100,
+    status: 1,
+    requests: [],
+    seasons: [],
+    ...overrides,
+  };
+}
+
+function makeRequest(seasonNumbers?: number[]) {
+  return {
+    id: 99,
+    status: 2,
+    media: {
+      id: 1,
+      tmdbId: 100,
+      status: 1,
+      seasons: seasonNumbers?.map(n => ({ seasonNumber: n, status: 2 })),
+    },
+    createdAt: '2024-01-01',
+    updatedAt: '2024-01-01',
+    requestedBy: { id: 1, email: 'test@test.com' },
+  };
+}
+
+// ── Movie paths ───────────────────────────────────────────────────────────────
+
+test('movie: no mediaInfo → AVAILABLE_FOR_REQUEST', () => {
+  const result = classifyAvailability(undefined, 'movie', null);
+  assert.equal(result.status, 'pass');
+  assert.equal(result.reasonCode, 'AVAILABLE_FOR_REQUEST');
+});
+
+test('movie: tracked (status 2) → ALREADY_AVAILABLE', () => {
+  const result = classifyAvailability(makeMediaInfo({ status: 2 }), 'movie', null);
+  assert.equal(result.status, 'blocked');
+  assert.equal(result.reasonCode, 'ALREADY_AVAILABLE');
+});
+
+test('movie: tracked (status 5) → ALREADY_AVAILABLE', () => {
+  const result = classifyAvailability(makeMediaInfo({ status: 5 }), 'movie', null);
+  assert.equal(result.status, 'blocked');
+  assert.equal(result.reasonCode, 'ALREADY_AVAILABLE');
+});
+
+test('movie: untracked but has requests → ALREADY_REQUESTED', () => {
+  const result = classifyAvailability(
+    makeMediaInfo({ status: 1, requests: [makeRequest()] }),
+    'movie',
+    null
+  );
+  assert.equal(result.status, 'blocked');
+  assert.equal(result.reasonCode, 'ALREADY_REQUESTED');
+});
+
+// ── TV: specific season in title ──────────────────────────────────────────────
+
+test('tv + seasonNumber: target season tracked → SEASON_AVAILABLE', () => {
+  const result = classifyAvailability(
+    makeMediaInfo({ seasons: [{ id: 1, seasonNumber: 2, status: 5, createdAt: '', updatedAt: '' }] }),
+    'tv',
+    2
+  );
+  assert.equal(result.status, 'blocked');
+  assert.equal(result.reasonCode, 'SEASON_AVAILABLE');
+});
+
+test('tv + seasonNumber: target season tracked (PENDING=2) → SEASON_AVAILABLE', () => {
+  const result = classifyAvailability(
+    makeMediaInfo({ seasons: [{ id: 1, seasonNumber: 1, status: 2, createdAt: '', updatedAt: '' }] }),
+    'tv',
+    1
+  );
+  assert.equal(result.status, 'blocked');
+  assert.equal(result.reasonCode, 'SEASON_AVAILABLE');
+});
+
+test('tv + seasonNumber: target season requested → SEASON_REQUESTED', () => {
+  const result = classifyAvailability(
+    makeMediaInfo({ requests: [makeRequest([3])] }),
+    'tv',
+    3
+  );
+  assert.equal(result.status, 'blocked');
+  assert.equal(result.reasonCode, 'SEASON_REQUESTED');
+});
+
+test('tv + seasonNumber: target season not tracked or requested → AVAILABLE_FOR_REQUEST', () => {
+  const result = classifyAvailability(
+    makeMediaInfo({ seasons: [{ id: 1, seasonNumber: 1, status: 5, createdAt: '', updatedAt: '' }] }),
+    'tv',
+    2
+  );
+  assert.equal(result.status, 'pass');
+  assert.equal(result.reasonCode, 'AVAILABLE_FOR_REQUEST');
+});
+
+test('tv + seasonNumber: no mediaInfo → AVAILABLE_FOR_REQUEST', () => {
+  const result = classifyAvailability(undefined, 'tv', 2);
+  assert.equal(result.status, 'pass');
+  assert.equal(result.reasonCode, 'AVAILABLE_FOR_REQUEST');
+});
+
+// ── TV: no specific season ────────────────────────────────────────────────────
+
+test('tv no season: show fully available (status 5) → ALREADY_AVAILABLE', () => {
+  const result = classifyAvailability(makeMediaInfo({ status: 5 }), 'tv', null);
+  assert.equal(result.status, 'blocked');
+  assert.equal(result.reasonCode, 'ALREADY_AVAILABLE');
+});
+
+test('tv no season: show partially available (status 4) → ALREADY_AVAILABLE', () => {
+  const result = classifyAvailability(makeMediaInfo({ status: 4 }), 'tv', null);
+  assert.equal(result.status, 'blocked');
+  assert.equal(result.reasonCode, 'ALREADY_AVAILABLE');
+});
+
+test('tv no season: show pending (status 2) → ALREADY_AVAILABLE', () => {
+  const result = classifyAvailability(makeMediaInfo({ status: 2 }), 'tv', null);
+  assert.equal(result.status, 'blocked');
+  assert.equal(result.reasonCode, 'ALREADY_AVAILABLE');
+});
+
+test('tv no season: show-level request (no seasons on request) → ALREADY_REQUESTED', () => {
+  const result = classifyAvailability(
+    makeMediaInfo({ requests: [makeRequest(/* no seasons */)] }),
+    'tv',
+    null
+  );
+  assert.equal(result.status, 'blocked');
+  assert.equal(result.reasonCode, 'ALREADY_REQUESTED');
+});
+
+test('tv no season: all show seasons tracked → ALREADY_AVAILABLE', () => {
+  const result = classifyAvailability(
+    makeMediaInfo({
+      seasons: [
+        { id: 1, seasonNumber: 1, status: 5, createdAt: '', updatedAt: '' },
+        { id: 2, seasonNumber: 2, status: 5, createdAt: '', updatedAt: '' },
+      ],
+    }),
+    'tv',
+    null,
+    {
+      showSeasons: [{ seasonNumber: 1 }, { seasonNumber: 2 }],
+    }
+  );
+  assert.equal(result.status, 'blocked');
+  assert.equal(result.reasonCode, 'ALREADY_AVAILABLE');
+});
+
+test('tv no season: all show seasons requested → ALREADY_REQUESTED', () => {
+  const result = classifyAvailability(
+    makeMediaInfo({ requests: [makeRequest([1, 2])] }),
+    'tv',
+    null,
+    {
+      showSeasons: [{ seasonNumber: 1 }, { seasonNumber: 2 }],
+    }
+  );
+  assert.equal(result.status, 'blocked');
+  assert.equal(result.reasonCode, 'ALREADY_REQUESTED');
+});
+
+test('tv no season: requestedSeasons all available → SEASON_AVAILABLE', () => {
+  const result = classifyAvailability(
+    makeMediaInfo({
+      seasons: [
+        { id: 1, seasonNumber: 1, status: 5, createdAt: '', updatedAt: '' },
+        { id: 2, seasonNumber: 2, status: 5, createdAt: '', updatedAt: '' },
+      ],
+    }),
+    'tv',
+    null,
+    {
+      showSeasons: [{ seasonNumber: 1 }, { seasonNumber: 2 }, { seasonNumber: 3 }],
+      requestedSeasons: [1, 2],
+    }
+  );
+  assert.equal(result.status, 'blocked');
+  assert.equal(result.reasonCode, 'SEASON_AVAILABLE');
+});
+
+test('tv no season: requestedSeasons all requested → SEASON_REQUESTED', () => {
+  const result = classifyAvailability(
+    makeMediaInfo({ requests: [makeRequest([1, 2])] }),
+    'tv',
+    null,
+    {
+      showSeasons: [{ seasonNumber: 1 }, { seasonNumber: 2 }, { seasonNumber: 3 }],
+      requestedSeasons: [1, 2],
+    }
+  );
+  assert.equal(result.status, 'blocked');
+  assert.equal(result.reasonCode, 'SEASON_REQUESTED');
+});
+
+test('tv no season: requestedSeasons all covered (mix available+requested) → SEASON_REQUESTED', () => {
+  const result = classifyAvailability(
+    makeMediaInfo({
+      seasons: [{ id: 1, seasonNumber: 1, status: 5, createdAt: '', updatedAt: '' }],
+      requests: [makeRequest([2])],
+    }),
+    'tv',
+    null,
+    {
+      showSeasons: [{ seasonNumber: 1 }, { seasonNumber: 2 }, { seasonNumber: 3 }],
+      requestedSeasons: [1, 2],
+    }
+  );
+  assert.equal(result.status, 'blocked');
+  assert.equal(result.reasonCode, 'SEASON_REQUESTED');
+});
+
+test('tv no season: no mediaInfo → AVAILABLE_FOR_REQUEST', () => {
+  const result = classifyAvailability(undefined, 'tv', null);
+  assert.equal(result.status, 'pass');
+  assert.equal(result.reasonCode, 'AVAILABLE_FOR_REQUEST');
+});
+
+test('tv no season: partial seasons, none of requestedSeasons covered → AVAILABLE_FOR_REQUEST', () => {
+  const result = classifyAvailability(
+    makeMediaInfo({
+      seasons: [{ id: 1, seasonNumber: 1, status: 5, createdAt: '', updatedAt: '' }],
+    }),
+    'tv',
+    null,
+    {
+      showSeasons: [{ seasonNumber: 1 }, { seasonNumber: 2 }, { seasonNumber: 3 }],
+      requestedSeasons: [2, 3],
+    }
+  );
+  assert.equal(result.status, 'pass');
+  assert.equal(result.reasonCode, 'AVAILABLE_FOR_REQUEST');
+});
+
+// ── reason string smoke tests ─────────────────────────────────────────────────
+
+test('movie ALREADY_AVAILABLE reason includes status label', () => {
+  const result = classifyAvailability(makeMediaInfo({ status: 3 }), 'movie', null);
+  assert.ok(result.reason?.toLowerCase().includes('processing'), `expected "processing" in "${result.reason}"`);
+});
+
+test('tv + seasonNumber SEASON_AVAILABLE reason mentions season number', () => {
+  const result = classifyAvailability(
+    makeMediaInfo({ seasons: [{ id: 1, seasonNumber: 4, status: 5, createdAt: '', updatedAt: '' }] }),
+    'tv',
+    4
+  );
+  assert.ok(result.reason?.includes('4'), `expected "4" in "${result.reason}"`);
+});

--- a/src/utils/availabilityClassifier.ts
+++ b/src/utils/availabilityClassifier.ts
@@ -95,8 +95,10 @@ function classifyTvSeason(mediaInfo: MediaInfo, seasonNumber: number): Classifie
 function classifyTvShow(mediaInfo: MediaInfo, options: ClassifierOptions): ClassifierResult {
   const { showSeasons, requestedSeasons } = options;
 
-  // Show tracked at show level (status 2–5 means it is already in the system)
-  if (isTracked(mediaInfo.status)) {
+  // Show tracked at show level — only applies when no explicit seasons are targeted.
+  // With requestedSeasons present, the per-season checks below are authoritative;
+  // a PARTIALLY_AVAILABLE show (status 4) should not block an untracked target season.
+  if (isTracked(mediaInfo.status) && (!requestedSeasons || requestedSeasons.length === 0)) {
     return blocked('ALREADY_AVAILABLE', 'Already in library (show-level)');
   }
 

--- a/src/utils/availabilityClassifier.ts
+++ b/src/utils/availabilityClassifier.ts
@@ -1,0 +1,176 @@
+import type { MediaInfo, ReasonCode } from '../types.js';
+import { isTracked, label } from './mediaStatus.js';
+
+export interface ClassifierResult {
+  status: 'pass' | 'blocked';
+  reasonCode: ReasonCode;
+  reason?: string;
+}
+
+export interface ClassifierOptions {
+  /** All regular seasons from TMDB (seasonNumber > 0). Used for "all seasons" checks on TV. */
+  showSeasons?: Array<{ seasonNumber: number }>;
+  /** Explicit seasons the caller wants to request. When provided, checked as a unit. */
+  requestedSeasons?: number[];
+}
+
+/**
+ * Pure availability classifier. No I/O, no cache, no network.
+ *
+ * Answers: "given what Seerr already knows about this media, should it be requested?"
+ *
+ * Scope is intentionally narrow — NOT_FOUND and SEASON_NOT_FOUND are lookup failures
+ * that happen before MediaInfo exists. The orchestrator handles those paths before
+ * calling this function. See docs/adr/0002-availability-classifier-narrow-scope.md.
+ */
+export function classifyAvailability(
+  mediaInfo: MediaInfo | undefined,
+  mediaType: 'movie' | 'tv',
+  seasonNumber: number | null,
+  options: ClassifierOptions = {}
+): ClassifierResult {
+  if (mediaType === 'movie') {
+    return classifyMovie(mediaInfo);
+  }
+  return classifyTv(mediaInfo, seasonNumber, options);
+}
+
+// ── Movie ─────────────────────────────────────────────────────────────────────
+
+function classifyMovie(mediaInfo: MediaInfo | undefined): ClassifierResult {
+  if (!mediaInfo) {
+    return pass();
+  }
+
+  if (isTracked(mediaInfo.status)) {
+    return blocked('ALREADY_AVAILABLE', `Already in library (${label(mediaInfo.status).toLowerCase()})`);
+  }
+
+  if (mediaInfo.requests && mediaInfo.requests.length > 0) {
+    return blocked('ALREADY_REQUESTED', 'Already requested');
+  }
+
+  return pass();
+}
+
+// ── TV ────────────────────────────────────────────────────────────────────────
+
+function classifyTv(
+  mediaInfo: MediaInfo | undefined,
+  seasonNumber: number | null,
+  options: ClassifierOptions
+): ClassifierResult {
+  if (!mediaInfo) {
+    return pass();
+  }
+
+  // ── Specific season in title ──────────────────────────────────────────────
+  if (seasonNumber !== null) {
+    return classifyTvSeason(mediaInfo, seasonNumber);
+  }
+
+  // ── No specific season ────────────────────────────────────────────────────
+  return classifyTvShow(mediaInfo, options);
+}
+
+function classifyTvSeason(mediaInfo: MediaInfo, seasonNumber: number): ClassifierResult {
+  const seasonInfo = mediaInfo.seasons?.find(s => s.seasonNumber === seasonNumber);
+  if (seasonInfo && isTracked(seasonInfo.status)) {
+    return blocked(
+      'SEASON_AVAILABLE',
+      `Season ${seasonNumber} is ${label(seasonInfo.status).toLowerCase()}`
+    );
+  }
+
+  const seasonRequested = mediaInfo.requests?.some(req =>
+    req.media.seasons?.some(s => s.seasonNumber === seasonNumber)
+  );
+  if (seasonRequested) {
+    return blocked('SEASON_REQUESTED', `Season ${seasonNumber} is already requested`);
+  }
+
+  return pass();
+}
+
+function classifyTvShow(mediaInfo: MediaInfo, options: ClassifierOptions): ClassifierResult {
+  const { showSeasons, requestedSeasons } = options;
+
+  // Show tracked at show level (status 2–5 means it is already in the system)
+  if (isTracked(mediaInfo.status)) {
+    return blocked('ALREADY_AVAILABLE', 'Already in library (show-level)');
+  }
+
+  // Show-level request (request with no seasons attached)
+  const hasShowLevelRequest = mediaInfo.requests?.some(
+    req => !req.media.seasons || req.media.seasons.length === 0
+  );
+  if (hasShowLevelRequest) {
+    return blocked('ALREADY_REQUESTED', 'Already requested (show-level)');
+  }
+
+  const regularSeasons = showSeasons?.filter(s => s.seasonNumber > 0) ?? [];
+
+  if (regularSeasons.length > 0) {
+    // Per-season predicate helpers — used by both the "all seasons" and "target seasons" checks
+    const isSeasonTracked = (sNum: number): boolean =>
+      mediaInfo.seasons?.some(si => si.seasonNumber === sNum && isTracked(si.status)) ?? false;
+    const isSeasonRequested = (sNum: number): boolean =>
+      mediaInfo.requests?.some(req => req.media.seasons?.some(s => s.seasonNumber === sNum)) ?? false;
+
+    // All seasons tracked
+    const allSeasonsAvailable = regularSeasons.every(s => isSeasonTracked(s.seasonNumber));
+    if (allSeasonsAvailable && mediaInfo.seasons && mediaInfo.seasons.length > 0) {
+      const nums = trackedSeasonNumbers(mediaInfo).join(', ');
+      return blocked('ALREADY_AVAILABLE', `All regular seasons already in library (${nums})`);
+    }
+
+    // All seasons requested
+    const allSeasonsRequested = regularSeasons.every(s => isSeasonRequested(s.seasonNumber));
+    if (allSeasonsRequested && mediaInfo.requests && mediaInfo.requests.length > 0) {
+      const nums = regularSeasons.map(s => s.seasonNumber).sort((a, b) => a - b).join(', ');
+      return blocked('ALREADY_REQUESTED', `All regular seasons already requested (${nums})`);
+    }
+
+    // Caller supplied an explicit requestedSeasons list — check as a unit
+    if (requestedSeasons && requestedSeasons.length > 0) {
+      if (requestedSeasons.every(isSeasonTracked)) {
+        return blocked('SEASON_AVAILABLE', `Requested season(s) already in library (${requestedSeasons.join(', ')})`);
+      }
+      if (requestedSeasons.every(isSeasonRequested)) {
+        return blocked('SEASON_REQUESTED', `Requested season(s) already requested (${requestedSeasons.join(', ')})`);
+      }
+      if (requestedSeasons.every(sNum => isSeasonTracked(sNum) || isSeasonRequested(sNum))) {
+        return blocked('SEASON_REQUESTED', `Requested season(s) already in library or requested (${requestedSeasons.join(', ')})`);
+      }
+    }
+  } else {
+    // Fallback: no seasons data — use show-level status
+    if (isTracked(mediaInfo.status)) {
+      return blocked('ALREADY_AVAILABLE', `Already in library (${label(mediaInfo.status).toLowerCase()})`);
+    }
+    if (mediaInfo.requests && mediaInfo.requests.length > 0) {
+      return blocked('ALREADY_REQUESTED', 'Already requested');
+    }
+  }
+
+  return pass();
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function pass(): ClassifierResult {
+  return { status: 'pass', reasonCode: 'AVAILABLE_FOR_REQUEST' };
+}
+
+function blocked(reasonCode: ReasonCode, reason: string): ClassifierResult {
+  return { status: 'blocked', reasonCode, reason };
+}
+
+function trackedSeasonNumbers(mediaInfo: MediaInfo): number[] {
+  return (
+    mediaInfo.seasons
+      ?.filter(s => s.seasonNumber > 0 && isTracked(s.status))
+      .map(s => s.seasonNumber)
+      .sort((a, b) => a - b) ?? []
+  );
+}

--- a/src/utils/availabilityClassifier.ts
+++ b/src/utils/availabilityClassifier.ts
@@ -144,10 +144,8 @@ function classifyTvShow(mediaInfo: MediaInfo, options: ClassifierOptions): Class
       }
     }
   } else {
-    // Fallback: no seasons data — use show-level status
-    if (isTracked(mediaInfo.status)) {
-      return blocked('ALREADY_AVAILABLE', `Already in library (${label(mediaInfo.status).toLowerCase()})`);
-    }
+    // Fallback: no showSeasons data — check requests only (show-level status already
+    // handled at the top of this function, so isTracked would be false here)
     if (mediaInfo.requests && mediaInfo.requests.length > 0) {
       return blocked('ALREADY_REQUESTED', 'Already requested');
     }
@@ -166,7 +164,7 @@ function blocked(reasonCode: ReasonCode, reason: string): ClassifierResult {
   return { status: 'blocked', reasonCode, reason };
 }
 
-function trackedSeasonNumbers(mediaInfo: MediaInfo): number[] {
+export function trackedSeasonNumbers(mediaInfo: MediaInfo): number[] {
   return (
     mediaInfo.seasons
       ?.filter(s => s.seasonNumber > 0 && isTracked(s.status))


### PR DESCRIPTION
- Add ReasonCode as named exported type in src/types.ts
- Add src/utils/availabilityClassifier.ts: pure function, no I/O, covers 7 classification paths (NOT_FOUND/SEASON_NOT_FOUND remain in the orchestrator per ADR 0002)
- Add 20 unit tests in src/utils/__tests__/availabilityClassifier.test.ts
- Refactor handleDedupeMode from ~780 lines to ~315 lines; now an orchestrator that searches, validates season existence, classifies, and enriches
- Collapse 14 enrichDedupeResult guard blocks to one unconditional call
- Import isTracked from mediaStatus.ts; no inline [2,3,4,5] checks remain in handleDedupeMode

Closes #153

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - More accurate availability status for movies and TV shows.
  - TV season checks now distinguish available, partially available, requested, and unavailable seasons.
  - Results consistently indicate when content is already available or has already been requested.
  - Alternate TV matches and franchise-related statuses are handled more reliably.
  - Improved validation helps prevent incorrect decisions when season information is incomplete.
- **Bug Fixes**
  - Improved fallback handling when TV season details are unavailable.
  - Fixed cases where requested seasons could be incorrectly marked unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->