### PR TITLE
ci: use npm trusted publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -4,9 +4,11 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   publish:
@@ -19,8 +21,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+
+      - name: Update npm for trusted publishing
+        run: npm install --global npm@^11.5.1
 
       - name: Install dependencies
         run: npm ci
@@ -46,8 +52,6 @@ jobs:
       - name: Publish to npm
         if: steps.check_version.outputs.exists == 'false'
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Skip publishing (version exists)
         if: steps.check_version.outputs.exists == 'true'


### PR DESCRIPTION
## Summary
- replace the expired npm token with GitHub Actions OIDC trusted publishing
- use Node.js 24 and npm 11 for trusted-publisher support
- add a manual trigger to recover the v2.3.0 npm publication without replacing its tag

## Verification
- actionlint .github/workflows/npm-publish.yml
- git diff --check
- npm test: 51 tests passed

Fixes the npm publication failure in run 33196491310.